### PR TITLE
ci: add Enforce License Compliance workflow

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,11 @@
+version: 3
+
+# FOSSA CLI for getsentry/action-enforce-license-compliance.
+# https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+
+project:
+  id: github.com/codecov/.github
+  url: https://github.com/codecov/.github
+
+telemetry:
+  scope: "off"

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,0 +1,15 @@
+name: Enforce License Compliance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  enforce-license-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Enforce License Compliance'
+        uses: getsentry/action-enforce-license-compliance@57ba820387a1a9315a46115ee276b2968da51f3d # main
+        with:
+          fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# FOSSA: setuptools discovery target at repo root (add real deps here if applicable).


### PR DESCRIPTION
Adds `.github/workflows/enforce-license-compliance.yml` using [getsentry/action-enforce-license-compliance](https://github.com/getsentry/action-enforce-license-compliance) so FOSSA runs on pull requests. Requires repository secret **`FOSSA_API_KEY`** (or org-level availability).

Also adds `.fossa.yml` / optional root `requirements.txt` when missing so `fossa analyze` can discover targets.